### PR TITLE
morphemes.h : Comment out an overloaded qHash()

### DIFF
--- a/ATSarf/src/util/morphemes.h
+++ b/ATSarf/src/util/morphemes.h
@@ -189,16 +189,16 @@ inline unsigned int qHash(const MorphemeDiacritic &m) {
 }
 
 //used for qHash(MorphemeDiacritics)
-template<class T>
-inline unsigned int qHash(const QList<T> &m) {
-    unsigned int h = 0;
-
-    for (int i = 0; i < m.size(); i++) {
-        h += qHash(m[i]);
-    }
-
-    return h;
-}
+//template<class T>
+//inline unsigned int qHash(const QList<T> &m) {
+//    unsigned int h = 0;
+//
+//    for (int i = 0; i < m.size(); i++) {
+//        h += qHash(m[i]);
+//    }
+//
+//    return h;
+//}
 
 
 


### PR DESCRIPTION
The signature
`inline unsigned int qHash(const QList<T> &m)`
now matches another method in qt's qt5/QtCore/qset.h module.
This causes ambiguity for the compiler.
Thus it is commented out.